### PR TITLE
fix: 更改选项描述,并且在关机/重启系统前加入关闭模拟器

### DIFF
--- a/Res/Localization/Strings.en-us.resx
+++ b/Res/Localization/Strings.en-us.resx
@@ -492,6 +492,6 @@
         <value>Disable MFA and Restart Emulator</value>
     </data>
     <data name="Restart" xml:space="preserve">
-        <value>Restart</value>
+        <value>RestartDevice</value>
     </data>
 </root>

--- a/Res/Localization/Strings.resx
+++ b/Res/Localization/Strings.resx
@@ -520,6 +520,6 @@
         <value>重启MFA和关闭模拟器</value>
     </data>
     <data name="Restart" xml:space="preserve">
-        <value>重启</value>
+        <value>重启系统</value>
     </data>
 </root>

--- a/Utils/MaaProcessor.cs
+++ b/Utils/MaaProcessor.cs
@@ -301,6 +301,7 @@ public class MaaProcessor
 
     private void ShutDown()
     {
+        CloseEmulator();
         Process.Start("shutdown", "/s /t 0");
     }
 
@@ -313,6 +314,7 @@ public class MaaProcessor
 
     private void Restart()
     {
+        CloseEmulator();
         Process.Start("shutdown", "/r /t 0");
     }
 


### PR DESCRIPTION
之前的选项有点描述不清,改了一下
关机/重启电脑时因为没关模拟器会等待一会,提前关了以减少等待的情况